### PR TITLE
Add Ruby 3.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     needs: ['build', 'memory-check']
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         os: ['ubuntu', 'macos', 'windows']
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -8,7 +8,7 @@ native_gemspec = eval(File.read 'nokolexbor.gemspec').tap do |spec|
   spec.metadata.delete('msys2_mingw_dependencies')
 end
 
-ENV['RUBY_CC_VERSION'] = %w{2.6.0 2.7.0 3.0.0 3.1.0 3.2.0}.join(':')
+ENV['RUBY_CC_VERSION'] = %w{2.6.0 2.7.0 3.0.0 3.1.0 3.2.0 3.3.0}.join(':')
 cross_platforms = %w[x86-mingw32 x64-mingw-ucrt x64-mingw32 x86-linux x86_64-linux aarch64-linux x86_64-darwin arm64-darwin]
 
 Rake::ExtensionTask.new('nokolexbor', native_gemspec) do |ext|


### PR DESCRIPTION
Adds support for Ruby 3.3. I was only able to test this on Linux, but generally I don't think there's a lot of breaking changes in 3.3, so it should be good.

Creating this because I see an error in my project:

```
nokolexbor-0.5.2-x86_64-linux requires ruby version < 3.3.dev, >= 2.6, which is
incompatible with the current version, 3.3.0
```

not sure if these changes are enough