### PR TITLE
Assign children in native C instead of ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ CPU: Apple M1 Pro (macOS). Run with: `ruby bench/bench.rb`
 | css          | 14505.5       | 140.9        | 102.93x faster  |
 | at_xpath     | 149.9         | 146.4        | same-ish        |
 | xpath        | 149.7         | 146.2        | same-ish        |
-| inner_html=  | 281967.9      | 49365.2      | 5.71x faster    |
+| inner_html=  | 320384.1      | 49518.6      | 6.47x faster    |
 
 <details>
 <summary>Raw data</summary>
@@ -187,16 +187,16 @@ Comparison:
 
 Warming up --------------------------------------
 Nokolexbor inner_html=
-                        43.045k i/100ms
-Nokogiri inner_html=     5.335k i/100ms
+                        44.564k i/100ms
+Nokogiri inner_html=     5.992k i/100ms
 Calculating -------------------------------------
 Nokolexbor inner_html=
-                        281.968k (±16.8%) i/s    (3.55 μs/i) -      5.510M in  20.031263s
-Nokogiri inner_html=     49.365k (±46.1%) i/s   (20.26 μs/i) -    725.560k in  20.192729s
+                        320.384k (±10.3%) i/s    (3.12 μs/i) -      3.209M in  10.113889s
+Nokogiri inner_html=     49.519k (±35.9%) i/s   (20.19 μs/i) -    431.424k in  10.029376s
 
 Comparison:
-Nokolexbor inner_html=:   281967.9 i/s
-Nokogiri inner_html=:    49365.2 i/s - 5.71x  slower
+Nokolexbor inner_html=:   320384.1 i/s
+Nokogiri inner_html=:    49518.6 i/s - 6.47x  slower
 ```
 </details>
 
@@ -209,7 +209,7 @@ Nokogiri inner_html=:    49365.2 i/s - 5.71x  slower
 | css          | 15701.1       | 136.3        | 115.21x faster  |
 | at_xpath     | 149.1         | 142.1        | same-ish        |
 | xpath        | 149.1         | 142.8        | same-ish        |
-| inner_html=  | 427517.6      | 39887.9      | 10.72x faster   |
+| inner_html=  | 324666.9      | 39664.0      | 8.19x faster   |
 
 <details>
 <summary>Raw data</summary>
@@ -277,15 +277,15 @@ Comparison:
 
 Warming up --------------------------------------
 Nokolexbor inner_html=
-                        53.261k i/100ms
-Nokogiri inner_html=     5.338k i/100ms
+                        53.518k i/100ms
+Nokogiri inner_html=     5.170k i/100ms
 Calculating -------------------------------------
 Nokolexbor inner_html=
-                        427.518k (±13.9%) i/s    (2.34 μs/i) -      8.415M in  20.161527s
-Nokogiri inner_html=     39.888k (±33.0%) i/s   (25.07 μs/i) -    688.602k in  20.070862s
+                        324.667k (±24.0%) i/s    (3.08 μs/i) -      6.101M in  20.003530s
+Nokogiri inner_html=     39.664k (±32.0%) i/s   (25.21 μs/i) -    687.610k in  20.104162s
 
 Comparison:
-Nokolexbor inner_html=:   427517.6 i/s
-Nokogiri inner_html=:    39887.9 i/s - 10.72x  slower
+Nokolexbor inner_html=:   324666.9 i/s
+Nokogiri inner_html=:    39664.0 i/s - 8.19x  slower
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/serpapi/nokolexbor/actions/workflows/ci.yml/badge.svg)](https://github.com/serpapi/nokolexbor/actions/workflows/ci.yml)
 
-Nokolexbor is a drop-in replacement for Nokogiri. It's 4.7x faster at parsing HTML and up to 1352x faster at CSS selectors.
+Nokolexbor is a drop-in replacement for Nokogiri. It's 5x faster at parsing HTML and up to 2393x faster at CSS selectors.
 
 It's a performance-focused HTML5 parser for Ruby based on [Lexbor](https://github.com/lexbor/lexbor/). It supports both CSS selectors and XPath. Nokolexbor's API is designed to be 1:1 compatible as much as possible with [Nokogiri's API](https://github.com/sparklemotion/nokogiri).
 
@@ -108,79 +108,184 @@ end
 
 Benchmarks of parsing Google search result page (367 KB) and finding nodes using CSS selectors and XPath.
 
-CPU: AMD Ryzen 5 5600 (Ubuntu 20.04 on Windows 10 WSL 2).
+CPU: Apple M1 Pro (macOS). Run with: `ruby bench/bench.rb`
 
-Run with: `ruby bench/bench.rb`
+### Ruby 3.4.6
 
-|            | Nokolexbor (iters/s) | Nokogiri (iters/s) | Diff |
-| ---------- | ------------- | ------------ | --------------- |
-| parsing    | 994.8         | 211.8        | 4.70x faster    |
-| at_css     | 202963.7      | 150.1        | 1352.33x faster |
-| css        | 9787.9        | 150.0        | 65.27x faster   |
-| at_xpath   | 154.6         | 153.2        | same-ish        |
-| xpath      | 154.3         | 153.2        | same-ish        |
+|              | Nokolexbor (iters/s) | Nokogiri (iters/s) | Diff |
+| ------------ | ------------- | ------------ | --------------- |
+| parsing      | 1422.2        | 321.5        | 4.42x faster    |
+| at_css       | 294440.7      | 141.0        | 2088.84x faster |
+| css          | 14505.5       | 140.9        | 102.93x faster  |
+| at_xpath     | 149.9         | 146.4        | same-ish        |
+| xpath        | 149.7         | 146.2        | same-ish        |
+| inner_html=  | 281967.9      | 49365.2      | 5.71x faster    |
 
 <details>
 <summary>Raw data</summary>
 
 ```
+ruby 3.4.6 (2025-09-16 revision dbd83256b1) +PRISM [arm64-darwin24]
 Warming up --------------------------------------
 Nokolexbor parse (367 KB)
-                       100.000  i/100ms
+                       146.000 i/100ms
 Nokogiri parse (367 KB)
-                        20.000  i/100ms
+                        32.000 i/100ms
 Calculating -------------------------------------
 Nokolexbor parse (367 KB)
-                        994.773  (± 0.9%) i/s -     19.900k in  20.006124s
+                          1.422k (± 1.5%) i/s  (703.16 μs/i) -     28.470k in  20.023416s
 Nokogiri parse (367 KB)
-                        211.793  (±12.3%) i/s -      4.180k in  20.093299s
+                        321.460 (± 5.3%) i/s    (3.11 ms/i) -      6.432k in  20.065421s
 
 Comparison:
-Nokolexbor parse (367 KB):      994.8 i/s
-Nokogiri parse (367 KB):      211.8 i/s - 4.70x  (± 0.00) slower
+Nokolexbor parse (367 KB):     1422.2 i/s
+Nokogiri parse (367 KB):      321.5 i/s - 4.42x  slower
 
 Warming up --------------------------------------
-   Nokolexbor at_css    20.195k i/100ms
-     Nokogiri at_css    15.000  i/100ms
+   Nokolexbor at_css    29.584k i/100ms
+     Nokogiri at_css    13.000 i/100ms
 Calculating -------------------------------------
-   Nokolexbor at_css    202.964k (± 0.7%) i/s -      4.059M in  20.000626s
-     Nokogiri at_css    150.084  (± 0.7%) i/s -      3.015k in  20.089207s
+   Nokolexbor at_css    294.441k (± 0.8%) i/s    (3.40 μs/i) -      5.917M in  20.096388s
+     Nokogiri at_css    140.959 (± 1.4%) i/s    (7.09 ms/i) -      2.821k in  20.016614s
 
 Comparison:
-   Nokolexbor at_css:   202963.7 i/s
-     Nokogiri at_css:      150.1 i/s - 1352.33x  (± 0.00) slower
+   Nokolexbor at_css:   294440.7 i/s
+     Nokogiri at_css:      141.0 i/s - 2088.84x  slower
 
 Warming up --------------------------------------
-      Nokolexbor css   977.000  i/100ms
-        Nokogiri css    15.000  i/100ms
+      Nokolexbor css     1.455k i/100ms
+        Nokogiri css    14.000 i/100ms
 Calculating -------------------------------------
-      Nokolexbor css      9.788k (± 0.4%) i/s -    196.377k in  20.063658s
-        Nokogiri css    149.956  (± 0.7%) i/s -      3.000k in  20.006363s
+      Nokolexbor css     14.506k (± 1.1%) i/s   (68.94 μs/i) -    291.000k in  20.063744s
+        Nokogiri css    140.921 (± 1.4%) i/s    (7.10 ms/i) -      2.828k in  20.073048s
 
 Comparison:
-      Nokolexbor css:     9787.9 i/s
-        Nokogiri css:      150.0 i/s - 65.27x  (± 0.00) slower
+      Nokolexbor css:    14505.5 i/s
+        Nokogiri css:      140.9 i/s - 102.93x  slower
 
 Warming up --------------------------------------
- Nokolexbor at_xpath    15.000  i/100ms
-   Nokogiri at_xpath    15.000  i/100ms
+ Nokolexbor at_xpath    15.000 i/100ms
+   Nokogiri at_xpath    14.000 i/100ms
 Calculating -------------------------------------
- Nokolexbor at_xpath    153.190  (± 0.7%) i/s -      3.075k in  20.073628s
-   Nokogiri at_xpath    154.588  (± 0.6%) i/s -      3.105k in  20.086664s
+ Nokolexbor at_xpath    149.877 (± 2.7%) i/s    (6.67 ms/i) -      3.000k in  20.029730s
+   Nokogiri at_xpath    146.385 (± 1.4%) i/s    (6.83 ms/i) -      2.940k in  20.088223s
 
 Comparison:
-   Nokogiri at_xpath:      154.6 i/s
- Nokolexbor at_xpath:      153.2 i/s - same-ish: difference falls within error
+ Nokolexbor at_xpath:      149.9 i/s
+   Nokogiri at_xpath:      146.4 i/s - same-ish: difference falls within error
 
 Warming up --------------------------------------
-    Nokolexbor xpath    15.000  i/100ms
-      Nokogiri xpath    15.000  i/100ms
+    Nokolexbor xpath    14.000 i/100ms
+      Nokogiri xpath    14.000 i/100ms
 Calculating -------------------------------------
-    Nokolexbor xpath    153.159  (± 0.7%) i/s -      3.075k in  20.077580s
-      Nokogiri xpath    154.322  (± 1.3%) i/s -      3.090k in  20.026288s
+    Nokolexbor xpath    149.654 (± 2.7%) i/s    (6.68 ms/i) -      2.996k in  20.032150s
+      Nokogiri xpath    146.179 (± 1.4%) i/s    (6.84 ms/i) -      2.926k in  20.020594s
 
 Comparison:
-      Nokogiri xpath:      154.3 i/s
-    Nokolexbor xpath:      153.2 i/s - same-ish: difference falls within error
+    Nokolexbor xpath:      149.7 i/s
+      Nokogiri xpath:      146.2 i/s - same-ish: difference falls within error
+
+Warming up --------------------------------------
+Nokolexbor inner_html=
+                        43.045k i/100ms
+Nokogiri inner_html=     5.335k i/100ms
+Calculating -------------------------------------
+Nokolexbor inner_html=
+                        281.968k (±16.8%) i/s    (3.55 μs/i) -      5.510M in  20.031263s
+Nokogiri inner_html=     49.365k (±46.1%) i/s   (20.26 μs/i) -    725.560k in  20.192729s
+
+Comparison:
+Nokolexbor inner_html=:   281967.9 i/s
+Nokogiri inner_html=:    49365.2 i/s - 5.71x  slower
+```
+</details>
+
+### Ruby 2.7.8
+
+|              | Nokolexbor (iters/s) | Nokogiri (iters/s) | Diff |
+| ------------ | ------------- | ------------ | --------------- |
+| parsing      | 1609.2        | 321.3        | 5.01x faster    |
+| at_css       | 329144.0      | 137.5        | 2393.44x faster |
+| css          | 15701.1       | 136.3        | 115.21x faster  |
+| at_xpath     | 149.1         | 142.1        | same-ish        |
+| xpath        | 149.1         | 142.8        | same-ish        |
+| inner_html=  | 427517.6      | 39887.9      | 10.72x faster   |
+
+<details>
+<summary>Raw data</summary>
+
+```
+ruby 2.7.8p225 (2023-03-30 revision 1f4d455848) [arm64-darwin24]
+Warming up --------------------------------------
+Nokolexbor parse (367 KB)
+                       162.000 i/100ms
+Nokogiri parse (367 KB)
+                        32.000 i/100ms
+Calculating -------------------------------------
+Nokolexbor parse (367 KB)
+                          1.609k (± 1.5%) i/s  (621.43 μs/i) -     32.238k in  20.038379s
+Nokogiri parse (367 KB)
+                        321.329 (± 8.7%) i/s    (3.11 ms/i) -      6.400k in  20.090350s
+
+Comparison:
+Nokolexbor parse (367 KB):     1609.2 i/s
+Nokogiri parse (367 KB):      321.3 i/s - 5.01x  slower
+
+Warming up --------------------------------------
+   Nokolexbor at_css    32.872k i/100ms
+     Nokogiri at_css    13.000 i/100ms
+Calculating -------------------------------------
+   Nokolexbor at_css    329.144k (± 0.6%) i/s    (3.04 μs/i) -      6.607M in  20.074781s
+     Nokogiri at_css    137.519 (± 0.7%) i/s    (7.27 ms/i) -      2.756k in  20.043157s
+
+Comparison:
+   Nokolexbor at_css:   329144.0 i/s
+     Nokogiri at_css:      137.5 i/s - 2393.44x  slower
+
+Warming up --------------------------------------
+      Nokolexbor css     1.571k i/100ms
+        Nokogiri css    13.000 i/100ms
+Calculating -------------------------------------
+      Nokolexbor css     15.701k (± 1.0%) i/s   (63.69 μs/i) -    314.200k in  20.013204s
+        Nokogiri css    136.285 (± 2.2%) i/s    (7.34 ms/i) -      2.730k in  20.039433s
+
+Comparison:
+      Nokolexbor css:    15701.1 i/s
+        Nokogiri css:      136.3 i/s - 115.21x  slower
+
+Warming up --------------------------------------
+ Nokolexbor at_xpath    14.000 i/100ms
+   Nokogiri at_xpath    14.000 i/100ms
+Calculating -------------------------------------
+ Nokolexbor at_xpath    149.054 (± 2.7%) i/s    (6.71 ms/i) -      2.982k in  20.020034s
+   Nokogiri at_xpath    142.148 (± 1.4%) i/s    (7.03 ms/i) -      2.856k in  20.097134s
+
+Comparison:
+ Nokolexbor at_xpath:      149.1 i/s
+   Nokogiri at_xpath:      142.1 i/s - 1.05x  slower
+
+Warming up --------------------------------------
+    Nokolexbor xpath    14.000 i/100ms
+      Nokogiri xpath    14.000 i/100ms
+Calculating -------------------------------------
+    Nokolexbor xpath    149.121 (± 2.0%) i/s    (6.71 ms/i) -      2.982k in  20.007593s
+      Nokogiri xpath    142.823 (± 2.1%) i/s    (7.00 ms/i) -      2.856k in  20.005681s
+
+Comparison:
+    Nokolexbor xpath:      149.1 i/s
+      Nokogiri xpath:      142.8 i/s - 1.04x  slower
+
+Warming up --------------------------------------
+Nokolexbor inner_html=
+                        53.261k i/100ms
+Nokogiri inner_html=     5.338k i/100ms
+Calculating -------------------------------------
+Nokolexbor inner_html=
+                        427.518k (±13.9%) i/s    (2.34 μs/i) -      8.415M in  20.161527s
+Nokogiri inner_html=     39.888k (±33.0%) i/s   (25.07 μs/i) -    688.602k in  20.070862s
+
+Comparison:
+Nokolexbor inner_html=:   427517.6 i/s
+Nokogiri inner_html=:    39887.9 i/s - 10.72x  slower
 ```
 </details>

--- a/bench/bench.rb
+++ b/bench/bench.rb
@@ -99,3 +99,22 @@ Benchmark.ips do |x|
   end
   x.compare!
 end
+
+nokolex_small = Nokolexbor::HTML(html_small)
+nokogiri_small = Nokogiri::HTML(html_small)
+inner_html_content = '<div><span>replaced</span><p>content</p></div>'
+
+Benchmark.ips do |x|
+  x.warmup = 5
+  x.time = 20
+
+  x.report("Nokolexbor inner_html=") do
+    node = nokolex_small.at_css('div')
+    node.inner_html = inner_html_content
+  end
+  x.report("Nokogiri inner_html=") do
+    node = nokogiri_small.at_css('div')
+    node.inner_html = inner_html_content
+  end
+  x.compare!
+end

--- a/ext/nokolexbor/nl_node.c
+++ b/ext/nokolexbor/nl_node.c
@@ -1081,6 +1081,28 @@ nl_node_add_child(VALUE self, VALUE new)
 }
 
 /**
+ * Set the inner HTML of this node, replacing all existing children.
+ *
+ * @param new [Node, DocumentFragment, NodeSet, String] The content to set.
+ * @return The content that was set.
+ */
+static VALUE
+nl_node_set_inner_html(VALUE self, VALUE new)
+{
+  lxb_dom_node_t *node = nl_rb_node_unwrap(self);
+
+  while (node->first_child != NULL) {
+    lxb_dom_node_destroy_deep(node->first_child);
+  }
+
+  if (RB_TYPE_P(new, T_STRING) && RSTRING_LEN(new) == 0) {
+    return new;
+  }
+
+  return nl_node_add_child(self, new);
+}
+
+/**
  * Get the type of this Node
  *
  * @return {Integer}
@@ -1263,6 +1285,8 @@ void Init_nl_node(void)
   rb_define_method(cNokolexborNode, "parse", nl_node_parse, 1);
   rb_define_method(cNokolexborNode, "add_sibling", nl_node_add_sibling, 2);
   rb_define_method(cNokolexborNode, "add_child", nl_node_add_child, 1);
+  rb_define_method(cNokolexborNode, "inner_html=", nl_node_set_inner_html, 1);
+  rb_define_alias(cNokolexborNode, "children=", "inner_html=");
   rb_define_method(cNokolexborNode, "node_type", nl_node_get_type, 0);
   rb_define_method(cNokolexborNode, "first_element_child", nl_node_first_element_child, 0);
   rb_define_method(cNokolexborNode, "last_element_child", nl_node_last_element_child, 0);

--- a/ext/nokolexbor/nl_node.c
+++ b/ext/nokolexbor/nl_node.c
@@ -1084,7 +1084,10 @@ nl_node_add_child(VALUE self, VALUE new)
  * Set the inner HTML of this node, replacing all existing children.
  *
  * @param new [Node, DocumentFragment, NodeSet, String] The content to set.
- * @return The content that was set.
+ * @return [Node,NodeSet,String] For non-empty content, returns the same value types as {#add_child}:
+ *   the reparented {Node} (if +new+ is a {Node}), or a {NodeSet} (if +new+ is a
+ *   {DocumentFragment}, {NodeSet}, or non-empty {String}). If +new+ is an empty
+ *   {String}, returns that empty string.
  */
 static VALUE
 nl_node_set_inner_html(VALUE self, VALUE new)

--- a/ext/nokolexbor/nl_node.c
+++ b/ext/nokolexbor/nl_node.c
@@ -1095,7 +1095,7 @@ nl_node_set_inner_html(VALUE self, VALUE new)
   lxb_dom_node_t *node = nl_rb_node_unwrap(self);
 
   while (node->first_child != NULL) {
-    lxb_dom_node_destroy_deep(node->first_child);
+    lxb_dom_node_remove(node->first_child);
   }
 
   if (RB_TYPE_P(new, T_STRING) && RSTRING_LEN(new) == 0) {

--- a/lib/nokolexbor/node.rb
+++ b/lib/nokolexbor/node.rb
@@ -276,16 +276,6 @@ module Nokolexbor
       self
     end
 
-    # Set the content of this Node.
-    #
-    # @param node [Node, DocumentFragment, NodeSet, String] The node to be added.
-    #
-    # @see #inner_html=
-    def children=(node)
-      children.remove
-      add_child(node)
-    end
-
     # Set the parent Node of this Node.
     #
     # @param parent_node [Node] The parent node.
@@ -315,7 +305,7 @@ module Nokolexbor
       Nokolexbor::DocumentFragment.new(document, tags, self)
     end
 
-    alias_method :inner_html=, :children=
+
 
     # Search this object for CSS +rules+. +rules+ must be one or more CSS
     # selectors.

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -762,17 +762,17 @@ HTML
 
   describe 'children=' do
     before do
-      @doc = Nokolexbor::HTML('')
-      @node = @doc.at_css('body')
+      @doc = Nokolexbor::HTML('<div><span>old</span>text<a href="#">link</a></div>')
+      @node = @doc.at_css('div')
     end
 
     it 'with String' do
-      @node.children = '<section class="a"></section><div></div>'
-      _(@node.inner_html).must_equal '<section class="a"></section><div></div>'
+      @node.children = '<section class="a"></section><p>hello</p>'
+      _(@node.inner_html).must_equal '<section class="a"></section><p>hello</p>'
     end
 
     it 'with DocumentFragment' do
-      @node.children = @node.fragment('<section class="a"></section><section class="b"></section')
+      @node.children = @node.fragment('<section class="a"></section><section class="b"></section>')
       _(@node.inner_html).must_equal '<section class="a"></section><section class="b"></section>'
     end
 
@@ -782,8 +782,87 @@ HTML
     end
 
     it 'with NodeSet' do
-      @node.children = @node.fragment('<section class="a"></section><section class="b"></section').children
+      @node.children = @node.fragment('<section class="a"></section><section class="b"></section>').children
       _(@node.inner_html).must_equal '<section class="a"></section><section class="b"></section>'
+    end
+
+    it 'replaces existing children' do
+      _(@node.children.size).must_equal 3
+      @node.children = '<b>replaced</b>'
+      _(@node.children.size).must_equal 1
+      _(@node.inner_html).must_equal '<b>replaced</b>'
+    end
+
+    it 'on empty node' do
+      doc = Nokolexbor::HTML('<div></div>')
+      node = doc.at_css('div')
+      node.children = '<span>new</span>'
+      _(node.inner_html).must_equal '<span>new</span>'
+    end
+  end
+
+  describe 'inner_html=' do
+    before do
+      @doc = Nokolexbor::HTML('<div><span>old</span>text<a href="#">link</a></div>')
+      @node = @doc.at_css('div')
+    end
+
+    it 'replaces existing children with HTML string' do
+      @node.inner_html = '<p>new content</p><b>bold</b>'
+      _(@node.inner_html).must_equal '<p>new content</p><b>bold</b>'
+    end
+
+    it 'replaces existing children completely' do
+      _(@node.children.size).must_equal 3
+      @node.inner_html = '<em>single</em>'
+      _(@node.children.size).must_equal 1
+    end
+
+    it 'with empty string removes all children' do
+      @node.inner_html = ''
+      _(@node.inner_html).must_equal ''
+      _(@node.children.size).must_equal 0
+    end
+
+    it 'is aliased as children=' do
+      @node.children = '<p>via children=</p>'
+      _(@node.inner_html).must_equal '<p>via children=</p>'
+    end
+
+    it 'with nested HTML' do
+      @node.inner_html = '<ul><li>one</li><li>two</li></ul>'
+      _(@node.inner_html).must_equal '<ul><li>one</li><li>two</li></ul>'
+      _(@node.at_css('li').text).must_equal 'one'
+    end
+
+    it 'with plain text' do
+      @node.inner_html = 'just text'
+      _(@node.inner_html).must_equal 'just text'
+      _(@node.children.size).must_equal 1
+      _(@node.child.text?).must_equal true
+    end
+
+    it 'with malformed HTML' do
+      @node.inner_html = '<div><span>unclosed'
+      _(@node.children).wont_be_empty
+      _(@node.at_css('span').text).must_equal 'unclosed'
+    end
+
+    it 'with deeply nested HTML' do
+      deeply_nested = '<div>' * 100 + 'content' + '</div>' * 100
+      @node.inner_html = deeply_nested
+      _(@node.inner_html).wont_be_empty
+    end
+
+    it 'with special characters' do
+      @node.inner_html = '<p>&amp; &lt; &gt; "quotes"</p>'
+      _(@node.at_css('p').text).must_include '&'
+      _(@node.at_css('p').text).must_include '<'
+    end
+
+    it 'preserves encoding' do
+      @node.inner_html = '<p>日本語テキスト</p>'
+      _(@node.at_css('p').text).must_equal '日本語テキスト'
     end
   end
 

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -824,6 +824,15 @@ HTML
       _(@node.children.size).must_equal 0
     end
 
+    it 'detached old children remain valid after replacement' do
+      old_child = @node.at_css('span')
+      @node.inner_html = '<em>new</em>'
+      _(@node.at_css('em')).wont_be_nil
+      _(old_child.parent).must_be_nil
+      _(old_child.name).must_equal 'span'
+      _(old_child.text).must_equal 'old'
+    end
+
     it 'is aliased as children=' do
       @node.children = '<p>via children=</p>'
       _(@node.inner_html).must_equal '<p>via children=</p>'


### PR DESCRIPTION
Not a big speed improvement in the grand scheme of things, but it is both faster and less resource hungry. The native C `inner_html=` replaces a Ruby method that builds a temporary `NodeSet`, crosses the Ruby/C boundary once per child node to call remove, then crosses again to call `add_child`, all of which allocates intermediate Ruby objects that immediately become garbage. 