### PR TITLE
Support `Node#pointer_id`

### DIFF
--- a/ext/nokolexbor/nl_node.c
+++ b/ext/nokolexbor/nl_node.c
@@ -921,6 +921,13 @@ nl_node_equals(VALUE self, VALUE other)
   return node1 == node2 ? Qtrue : Qfalse;
 }
 
+static VALUE
+nl_node_pointer_id(VALUE self)
+{
+  lxb_dom_node_t *node = nl_rb_node_unwrap(self);
+  return ULL2NUM((unsigned long long)(uintptr_t)node);
+}
+
 const lxb_char_t *
 lxb_dom_node_name_qualified(lxb_dom_node_t *node, size_t *len)
 {
@@ -1241,6 +1248,7 @@ void Init_nl_node(void)
   rb_define_method(cNokolexborNode, "[]=", nl_node_set_attr, 2);
   rb_define_method(cNokolexborNode, "remove_attr", nl_node_remove_attr, 1);
   rb_define_method(cNokolexborNode, "==", nl_node_equals, 1);
+  rb_define_method(cNokolexborNode, "pointer_id", nl_node_pointer_id, 0);
   rb_define_method(cNokolexborNode, "css_impl", nl_node_css, 1);
   rb_define_method(cNokolexborNode, "at_css_impl", nl_node_at_css, 1);
   rb_define_method(cNokolexborNode, "inner_html", nl_node_inner_html, -1);

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -1053,4 +1053,34 @@ HTML
     _(doc.at_css('.a').path).must_equal '/html/body/div/span/a[1]'
     _(doc.at_css('.b').path).must_equal '/html/body/div/span/a[2]'
   end
+
+  describe 'pointer_id' do
+    it 'returns an Integer' do
+      doc = Nokolexbor::HTML('<div></div>')
+      node = doc.at_css('div')
+      _(node.pointer_id).must_be_kind_of Integer
+    end
+
+    it 'is the same for two wrappers of the same node' do
+      doc = Nokolexbor::HTML('<div></div>')
+      n1 = doc.at_css('div')
+      n2 = doc.at_css('div')
+      _(n1.pointer_id).must_equal n2.pointer_id
+    end
+
+    it 'differs for different nodes' do
+      doc = Nokolexbor::HTML('<div></div><p></p>')
+      div = doc.at_css('div')
+      p_node = doc.at_css('p')
+      _(div.pointer_id).wont_equal p_node.pointer_id
+    end
+
+    it 'is stable across DOM mutations' do
+      doc = Nokolexbor::HTML('<div><p></p></div>')
+      p_node = doc.at_css('p')
+      id_before = p_node.pointer_id
+      doc.at_css('body').add_child(p_node)
+      _(doc.at_css('body > p').pointer_id).must_equal id_before
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `Nokolexbor::Node#pointer_id`, which returns the underlying C node pointer as an `Integer`.

## Example

```ruby
require "nokolexbor"

doc = Nokolexbor::HTML("<div id='x'><p>hi</p></div>")

n1 = doc.at_css("#x")
n2 = doc.at_css("#x")

n1.pointer_id == n2.pointer_id   # => true
n1.pointer_id.class              # => Integer
```

## Compatibility

This PR adds `Node#pointer_id`, matching `Nokogiri::XML::Node#pointer_id`.
Both return an Integer derived from the underlying C node pointer, so the same C node yields the same pointer_id.
